### PR TITLE
feature/responsive header

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,31 @@ The following CSS was added to `assets/css/schemes/fruit.css` (based on Congo's 
 	--color-secondary-900: 136, 19, 55;
 }
 ```
+
+## Menu Header
+The following CSS was added to `assets/css/custom.css` in order to show/hide the desktop or mobile menu header based on the width of the screen:
+
+```css
+@media (min-width: 740px) {
+	#header-narrow {
+		display: none !important;
+	}
+
+	.header-wide {
+		display: block !important;
+	}
+}
+
+/* header for narrow screens */
+@media (max-width: 740px) {
+	#header-narrow {
+		display: block !important;
+	}
+
+	.header-wide {
+		display: none !important;
+	}
+}
+```
+
+The HTML was inspired by a combination of Congo Theme's [basic](https://github.com/jpanther/congo/blob/stable/layouts/partials/header/basic.html) and [hamburger](https://github.com/jpanther/congo/blob/stable/layouts/partials/header/hamburger.html) layouts. Its HTML code is available at [`layouts/partials/header/custom.html`](/layouts/partials/header/custom.html).

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,40 +1,71 @@
+/* header for wide screens */
+@media (min-width: 740px) {
+	#header-narrow {
+		display: none !important;
+	}
+
+	.header-wide {
+		display: block !important;
+	}
+}
+
+/* header for narrow screens */
+@media (max-width: 740px) {
+	#header-narrow {
+		display: block !important;
+	}
+
+	.header-wide {
+		display: none !important;
+	}
+}
+
+/* disable horizontal scrolling */
 body {
 	overflow-x: hidden;
 }
 
+/* hyperlinks conform to screen width */
 a {
 	max-width: 100vw !important;
 	word-wrap: break-word !important;
 }
 
+/* YouTube videos conform to parent width */
 iframe {
 	max-width: 100%;
 }
 
+/* KaTeX multi-line blocks shrink font size in narrow screens */
 @media (max-width: 640px) {
 	span.katex-display > * {
 		font-size: 0.65rem !important;
 	}
 }
 
+/* Fira Code definition */
 @font-face {
 	font-family: 'Fira Code';
 	src: local('FiraCode-Regular'), url('/FiraCode-Regular.ttf') format('truetype');
 }
 
+/* fixed-width font priorities */
 code {
 	font-family: 'Cascadia Code', 'Fira Code', monospace !important;
 }
 
+/* diagrams with transparent background */
 pre.mermaid {
 	background-color: transparent !important;
 }
 
+/* search menu results more text lengths */
 #search-results > li > a > div.grow {
 	max-width: calc(100% - 1.5rem) !important;
 	word-wrap: break-word !important;
 }
 
+/* inline code blocks and quotes without decorations */
 .prose :where(code):not(:where([class~="not-prose"] *))::before {
 	content: unset !important;
 }
@@ -51,11 +82,12 @@ pre.mermaid {
 	content: unset !important;
 }
 
-
+/* square unordered list style */
 ul > li > ul {
 	list-style-type: square !important;
 }
 
+/* wider content width */
 .max-w-7xl {
 	max-width: 100rem !important;
 }

--- a/config.yml
+++ b/config.yml
@@ -38,6 +38,8 @@ params:
   homepage:
     layout: profile
     showRecent: true
+  header:
+    layout: custom
   article:
     showBreadcrumbs: true
     showTableOfContents: true
@@ -57,6 +59,7 @@ params:
       - pinterest
   list:
     showTableOfContents: true
+    showBreadcrumbs: true
 markup:
   highlight:
     noClasses: false

--- a/content/posts/configurations/congo.md
+++ b/content/posts/configurations/congo.md
@@ -487,6 +487,7 @@ These configurations are in this section because they do not fit in a coherent c
 * Content search is enabled
 * Recent posts from the blog are shown in the homepage
 * The homepage is rendered as profile configuration
+* A [custom](#menu-header) menu header layout is used
 * A table of contents is shown for every [list page](https://gohugo.io/templates/lists/)
 
 ```yaml
@@ -500,6 +501,9 @@ params:
   homepage:
     layout: profile
     showRecent: true
+  header:
+    layout: custom
   list:
     showTableOfContents: true
+    showBreadcrumbs: true
 ```

--- a/content/posts/configurations/congo.md
+++ b/content/posts/configurations/congo.md
@@ -320,6 +320,34 @@ The following CSS was added to `assets/css/schemes/fruit.css` (based on Congo's 
 }
 ```
 
+## Menu Header
+The following CSS was added to `assets/css/custom.css` in order to show/hide the desktop or mobile menu header based on the width of the screen:
+
+```css
+@media (min-width: 740px) {
+	#header-narrow {
+		display: none !important;
+	}
+
+	.header-wide {
+		display: block !important;
+	}
+}
+
+/* header for narrow screens */
+@media (max-width: 740px) {
+	#header-narrow {
+		display: block !important;
+	}
+
+	.header-wide {
+		display: none !important;
+	}
+}
+```
+
+The HTML was inspired by a combination of Congo Theme's [basic](https://github.com/jpanther/congo/blob/stable/layouts/partials/header/basic.html) and [hamburger](https://github.com/jpanther/congo/blob/stable/layouts/partials/header/hamburger.html) layouts. Its HTML code is available at [`layouts/partials/header/custom.html`](https://github.com/AppleGamer22/applegamer22.github.io/blob/master/layouts/partials/header/custom.html).
+
 # Configuration
 ## Hugo
 The following YAML snippets are taken from my [`config.yml`](https://github.com/AppleGamer22/applegamer22.github.io/blob/post/congo/config.yml), and always start from the root level of the YAML tree.

--- a/layouts/partials/header/custom.html
+++ b/layouts/partials/header/custom.html
@@ -1,0 +1,66 @@
+<!--
+	inspired by:
+		* <https://github.com/jpanther/congo/blob/stable/layouts/partials/header/basic.html>
+		* <https://github.com/jpanther/congo/blob/stable/layouts/partials/header/hamburger.html>
+-->
+<header class="py-6 font-semibold text-neutral-900 dark:text-neutral print:hidden sm:py-10">
+	<nav class="flex justify-between">
+		{{/* Site logo/title */}}
+		<div>
+			{{ if .Site.Params.Logo -}}
+				{{ $logo := resources.Get .Site.Params.Logo }}
+				{{ if $logo }}
+					<a href="{{ "" | relLangURL }}">
+						<img src="{{ $logo.RelPermalink }}" width="{{ div $logo.Width 2 }}" height="{{ div $logo.Height 2 }}" class="max-h-[10rem] max-w-[10rem] object-scale-down object-left" alt="{{ .Site.Title }}">
+					</a>
+				{{ end }}
+			{{ else }}
+				<a class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2" rel="me" href="{{ "" | relLangURL }}">{{ .Site.Title | markdownify | emojify }}</a>
+			{{- end }}
+			{{ partial "translations.html" . }}
+		</div>
+		{{ if or .Site.Menus.main (.Site.Params.enableSearch | default false) }}
+			<ul class="flex flex-col list-none ltr:text-right rtl:text-left sm:flex-row">
+				{{ if .Site.Menus.main }}
+					{{ range .Site.Menus.main }}
+						<li class="header-wide mb-1 sm:mb-0 ltr:sm:mr-7 ltr:sm:last:mr-0 rtl:sm:ml-7 rtl:sm:last:ml-0">
+							<a class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2" href="{{ .URL }}" title="{{ .Title }}">{{ .Name | markdownify | emojify }}</a>
+						</li>
+					{{ end }}
+				{{ end }}
+				{{ if .Site.Params.enableSearch | default false }}
+					<li class="ltr:sm:mr-7 ltr:sm:last:mr-0 rtl:sm:ml-7 rtl:sm:last:ml-0">
+						<button id="search-button" class="text-base hover:text-primary-600 dark:hover:text-primary-400" title="{{ i18n " search.open_button_title" }}">
+							{{ partial "icon.html" "search" }}
+						</button>
+					</li>
+				{{ end }}
+				<li id="header-narrow" class="ltr:sm:mr-7 ltr:sm:last:mr-0 rtl:sm:ml-7 rtl:sm:last:ml-0">
+					<label id="menu-button" for="menu-controller" class="block">
+						<input type="checkbox" id="menu-controller" class="hidden">
+						<div class="cursor-pointer hover:text-primary-600 dark:hover:text-primary-400">
+							{{ partial "icon.html" "bars" }}
+						</div>
+						<div id="menu-wrapper" class="fixed inset-0 z-30 invisible w-screen h-screen m-auto overflow-auto transition-opacity opacity-0 cursor-default bg-neutral-100/50 backdrop-blur-sm dark:bg-neutral-900/50">
+							<ul class="flex flex-col w-full px-6 py-6 mx-auto overflow-visible list-none max-w-7xl ltr:text-right rtl:text-left sm:px-14 sm:py-10 sm:pt-10 md:px-24 lg:px-32">
+								<li class="mb-1">
+									<span class="cursor-pointer hover:text-primary-600 dark:hover:text-primary-400">{{ partial
+										"icon.html" "xmark" }}</span>
+								</li>
+								{{ if .Site.Menus.main }}
+									{{ range .Site.Menus.main }}
+										<li class="mb-1">
+											<a class="decoration-primary-500 hover:underline hover:decoration-2 hover:underline-offset-2" href="{{ .URL }}" title="{{ .Title }}">{{ .Name | markdownify | emojify }}</a>
+										</li>
+									{{ end }}
+								{{ end }}
+							</ul>
+						</div>
+					</label>
+				</li>
+			</ul>
+		{{ end }}
+	</nav>
+</header>
+
+

--- a/layouts/partials/header/custom.html
+++ b/layouts/partials/header/custom.html
@@ -62,5 +62,3 @@
 		{{ end }}
 	</nav>
 </header>
-
-


### PR DESCRIPTION
The following CSS was added to `assets/css/custom.css` in order to show/hide the desktop or mobile menu header based on the width of the screen:

```css
@media (min-width: 740px) {
	#header-narrow {
		display: none !important;
	}

	.header-wide {
		display: block !important;
	}
}

/* header for narrow screens */
@media (max-width: 740px) {
	#header-narrow {
		display: block !important;
	}

	.header-wide {
		display: none !important;
	}
}
```

The HTML was inspired by a combination of Congo Theme's [basic](https://github.com/jpanther/congo/blob/stable/layouts/partials/header/basic.html) and [hamburger](https://github.com/jpanther/congo/blob/stable/layouts/partials/header/hamburger.html) layouts. Its HTML code is available at [`layouts/partials/header/custom.html`](/layouts/partials/header/custom.html).